### PR TITLE
indent output JSON by 2 spaces, fix typo about options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ grunt.initConfig({
         defaultTarget: {
             options: {
                 devDependencies: true,
-                excludedDependencies: [ 'fsevents' ]
+                excludeDependencies: [ 'fsevents' ]
             },
         }
     }

--- a/tasks/custom-shrinkwrap.js
+++ b/tasks/custom-shrinkwrap.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
                 delete shrinkwrappedJson.dependencies[excludedDependency];
             });
 
-            grunt.file.write('./npm-shrinkwrap.json', JSON.stringify(shrinkwrappedJson));
+            grunt.file.write('./npm-shrinkwrap.json', JSON.stringify(shrinkwrappedJson, null, '  '));
 
             grunt.verbose.writeln(
                 'removed',


### PR DESCRIPTION
Thanks for this grunt task. It has been really useful.

I think we should indent the generated JSON file by 2 spaces because:
* It will play nicely with an existing `npm-shrinkwrap.json` file
* It's easier to diff & verify any new dependency being added to the shrinkwrap file.

Please let me know what you think.